### PR TITLE
Fix stdout/stderr synchronization

### DIFF
--- a/lib/protoflow-blocks/src/blocks/sys/write_stderr.rs
+++ b/lib/protoflow-blocks/src/blocks/sys/write_stderr.rs
@@ -56,11 +56,10 @@ impl WriteStderr {
 
 impl Block for WriteStderr {
     fn execute(&mut self, runtime: &dyn BlockRuntime) -> BlockResult {
-        let mut stderr = std::io::stderr().lock();
-
         runtime.wait_for(&self.input)?;
 
         while let Some(message) = self.input.recv()? {
+            let mut stderr = std::io::stderr().lock();
             std::io::Write::write_all(&mut stderr, &message)?;
         }
 

--- a/lib/protoflow-blocks/src/blocks/sys/write_stdout.rs
+++ b/lib/protoflow-blocks/src/blocks/sys/write_stdout.rs
@@ -56,11 +56,10 @@ impl WriteStdout {
 
 impl Block for WriteStdout {
     fn execute(&mut self, runtime: &dyn BlockRuntime) -> BlockResult {
-        let mut stdout = std::io::stdout().lock();
-
         runtime.wait_for(&self.input)?;
 
         while let Some(message) = self.input.recv()? {
+            let mut stdout = std::io::stdout().lock();
             std::io::Write::write_all(&mut stdout, &message)?;
         }
 


### PR DESCRIPTION
Working on the Split block, when trying to print the splitted messages to the console, having multiple stdout blocks they both try to lock the stdout simultaneously.