### PR TITLE
Implement CI for pull requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,7 @@ jobs:
         id: install-rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.74.0
+          toolchain: 1.75.0
           components: rustfmt
           targets: ${{ matrix.target }}
       - name: Build library

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,16 +76,6 @@ jobs:
         if: ${{ steps.check-tests.outcome == 'success' }}
         run: |
           cargo +${{ steps.install-rust.outputs.name }} test --target ${{ matrix.target }} --workspace --test "*" --no-fail-fast
-      - name: Obtain job id
-        id: obtain-job-id
-        if: ${{ always() }}
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          jobs=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs)
-          job_id=$(echo $jobs | jq -r '.jobs[] | select(.name | contains("${{ matrix.name }}")) | .id')
-          echo "result=$job_id" >> $GITHUB_OUTPUT
   review-pr:
     name: Review PR
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,7 +95,7 @@ jobs:
             if (${{ needs.check-formatting.result != 'success' }} ||
                 ${{ needs.check-targets.result != 'success' }}) {
               let FORMATTING_JOB_NAME = 'Check formatting';
-              let VERBOSE = false;
+              let VERBOSE = true;
               let response = undefined;
 
               let body = `

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,7 @@ jobs:
         run: |
           echo "steps.check-examples.conclusion = ${{ steps.check-examples.conclusion }}"
           echo "steps.check-examples.outcome = ${{ steps.check-examples.outcome }}"
-          cargo +1.80.0 test --target ${{ matrix.target }} --workspace --no-fail-fast
+          cargo +1.80.0 test --target ${{ matrix.target }} --workspace --test * --no-fail-fast
       - name: Obtain job id
         id: obtain-job-id
         if: ${{ always() }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,32 +49,33 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Install Rust
+        id: install-rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.80.0
+          toolchain: 1.70.0
           components: rustfmt
           targets: ${{ matrix.target }}
       - name: Build library
         id: check-lib
         if: ${{ always() }}
-        run: cargo +1.80.0 check --target ${{ matrix.target }} --workspace --lib
+        run: cargo +${{ steps.install-rust.outputs.name }} check --target ${{ matrix.target }} --workspace --lib
       - name: Build binaries
         id: check-bins
         if: ${{ always() }}
-        run: cargo +1.80.0 check --target ${{ matrix.target }} --workspace --bins
+        run: cargo +${{ steps.install-rust.outputs.name }} check --target ${{ matrix.target }} --workspace --bins
       - name: Build tests
         id: check-tests
         if: ${{ always() }}
-        run: cargo +1.80.0 check --target ${{ matrix.target }} --workspace --tests
+        run: cargo +${{ steps.install-rust.outputs.name }} check --target ${{ matrix.target }} --workspace --tests
       - name: Build examples
         id: check-examples
         if: ${{ always() }}
-        run: cargo +1.80.0 check --target ${{ matrix.target }} --workspace --examples
+        run: cargo +${{ steps.install-rust.outputs.name }} check --target ${{ matrix.target }} --workspace --examples
       - name: Run tests
         id: run-tests
         if: ${{ steps.check-tests.outcome == 'success' }}
         run: |
-          cargo +1.80.0 test --target ${{ matrix.target }} --workspace --test "*" --no-fail-fast
+          cargo +${{ steps.install-rust.outputs.name }} test --target ${{ matrix.target }} --workspace --test "*" --no-fail-fast
       - name: Obtain job id
         id: obtain-job-id
         if: ${{ always() }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,13 +52,13 @@ jobs:
           targets: ${{ matrix.target }}
       - name: Check binaries
         id: bins
-        run: cargo +1.80.0-${{ matrix.target }} check --workspace --bins
+        run: cargo +1.80.0 check --target ${{ matrix.target }} --workspace --bins
       - name: Check tests
         id: tests
-        run: cargo +1.80.0-${{ matrix.target }} check --workspace --tests
+        run: cargo +1.80.0 check --target ${{ matrix.target }} --workspace --tests
       - name: Check examples
         id: examples
-        run: cargo +1.80.0-${{ matrix.target }} check --workspace --examples
+        run: cargo +1.80.0 check --target ${{ matrix.target }} --workspace --examples
   review-pr:
     name: Review PR
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,19 +24,24 @@ jobs:
     name: Review PR
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - name: Approve PR
+        if: ${{ success() }}
+        uses: actions/github-script@v7
         with:
           script: |
-            if (${{ success() }} == true) {
-              await github.rest.pulls.createReview({
-                ...context.repo,
-                pull_number: context.issue.number,
-                event: 'APPROVE',
-              });
-            } else {
-              await github.rest.pulls.createReview({
-                ...context.repo,
-                pull_number: context.issue.number,
-                event: 'REQUEST_CHANGES',
-                body: 'TBD',
-              });
+            await github.rest.pulls.createReview({
+              ...context.repo,
+              pull_number: context.issue.number,
+              event: 'APPROVE',
+            });
+      - name: Request changes
+        if: ${{ failure() }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.pulls.createReview({
+              ...context.repo,
+              pull_number: context.issue.number,
+              event: 'REQUEST_CHANGES',
+              body: 'TBD',
+            });

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,9 +50,6 @@ jobs:
           toolchain: 1.80.0
           components: rustfmt
           targets: ${{ matrix.target }}
-      - name: Check formatting
-        id: formatting
-        run: cargo +1.80.0-${{ matrix.target }} fmt --all -- --check
       - name: Check binaries
         id: bins
         run: cargo +1.80.0-${{ matrix.target }} check --workspace --bins

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,7 @@ jobs:
         run: |
           echo "steps.check-tests.conclusion = ${{ steps.check-tests.conclusion }}"
           echo "steps.check-tests.outcome = ${{ steps.check-tests.outcome }}"
-          cargo +1.80.0 test --target ${{ matrix.target }} --workspace --test * --no-fail-fast
+          cargo +1.80.0 test --target ${{ matrix.target }} --workspace --test "*" --no-fail-fast
       - name: Obtain job id
         id: obtain-job-id
         if: ${{ always() }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # See: https://docs.github.com/en/actions/writing-workflows
 ---
-name: Release
+name: CI
 
 on:
   pull_request:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,7 @@ jobs:
   review-pr:
     name: Review PR
     runs-on: ubuntu-latest
+    if: ${{ always() }}
     needs:
       - check-formatting
     permissions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,6 +72,7 @@ jobs:
       - name: Obtain job id
         id: obtain-job-id
         if: ${{ always() }}
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,7 +102,7 @@ jobs:
             ## ⚠️ CI failed
 
             | Platform | Name | Status | Details |
-            | --- | --- | --- | --- |`;
+            | --- | --- | --- | --- |\n`;
 
               function get_job_url(job_id) {
                 return `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/jobs/${job_id}?check_suite_focus=true`;

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
@@ -38,6 +41,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -131,10 +131,7 @@ jobs:
                     (VERBOSE || job.conclusion == 'failure')) {
                   let platform = job.name.split(' ')[1];
                   for (let step of job.steps) {
-                    console.log('Step name: ', step.name);
-                    console.log('Step conclusion: ', step.conclusion);
-                    console.log('Step outcome: ', step.outcome);
-                    if (step.name.startsWith('Build ') || step.name.startsWith('Run ') &&
+                    if ((step.name.startsWith('Build ') || step.name.startsWith('Run ')) &&
                         (VERBOSE || step.conclusion == 'failure')) {
                       let name = step.name;
                       let icon = '';

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,8 +73,8 @@ jobs:
         id: run-tests
         if: ${{ always() }}
         run: |
-          echo "steps.check-examples.conclusion = ${{ steps.check-examples.conclusion }}"
-          echo "steps.check-examples.outcome = ${{ steps.check-examples.outcome }}"
+          echo "steps.check-tests.conclusion = ${{ steps.check-tests.conclusion }}"
+          echo "steps.check-tests.outcome = ${{ steps.check-tests.outcome }}"
           cargo +1.80.0 test --target ${{ matrix.target }} --workspace --test * --no-fail-fast
       - name: Obtain job id
         id: obtain-job-id

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,7 @@ jobs:
         run: cargo +1.80.0 check --target ${{ matrix.target }} --workspace --examples
       - name: Run tests
         id: run-tests
-        if: ${{ steps.check-tests.outcome == 'success' }}
+        if: ${{ steps.check-tests.conclusion == 'success' }}
         run: cargo +1.80.0 test --target ${{ matrix.target }} --workspace --no-fail-fast
       - name: Obtain job id
         id: obtain-job-id

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,42 @@
+# See: https://docs.github.com/en/actions/writing-workflows
+---
+name: Release
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    
+jobs:
+  check-formatting:
+    name: Check formatting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.80.0
+          components: rustfmt
+      - name: Check formatting
+        run: cargo +1.80.0 fmt --all -- --check 2>/dev/null
+  review-pr:
+    name: Review PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            if (${{ success() }} == true) {
+              await github.rest.pulls.createReview({
+                ...context.repo,
+                pull_number: context.issue.number,
+                event: 'APPROVE',
+              });
+            } else {
+              await github.rest.pulls.createReview({
+                ...context.repo,
+                pull_number: context.issue.number,
+                event: 'REQUEST_CHANGES',
+                body: 'TBD',
+              });

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,7 +76,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          jobs=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id}}/attempts/${{ github.run_attempt }}/jobs)
+          jobs=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs)
           job_id=$(echo $jobs | jq -r '.jobs[] | select(.name | contains("${{ matrix.name }}")) | .id')
           echo "result=$job_id" >> $GITHUB_OUTPUT
   review-pr:
@@ -127,7 +127,7 @@ jobs:
               let response = await github.rest.actions.getWorkflowRunAttempt({
                 ...context.repo,
                 run_id: context.runId,
-                attempt_number: context.runAttempt
+                attempt_number: context.runAttempt || 1
               });
 
               let formatting_job = response.data.jobs.find(job => job.name.includes(FORMATTING_JOB_NAME));

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,10 +71,8 @@ jobs:
         run: cargo +1.80.0 check --target ${{ matrix.target }} --workspace --examples
       - name: Run tests
         id: run-tests
-        if: ${{ always() }}
+        if: ${{ steps.check-tests.outcome == 'success' }}
         run: |
-          echo "steps.check-tests.conclusion = ${{ steps.check-tests.conclusion }}"
-          echo "steps.check-tests.outcome = ${{ steps.check-tests.outcome }}"
           cargo +1.80.0 test --target ${{ matrix.target }} --workspace --test "*" --no-fail-fast
       - name: Obtain job id
         id: obtain-job-id

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
           - name: Linux
             target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-          - name: MacOS
+          - name: macOS
             target: x86_64-apple-darwin
             os: macos-latest
           - name: Windows

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
           targets: ${{ matrix.target }}
       - name: Check formatting
         id: formatting
-        run: cargo +1.80.0-${{ matrix.target }} fmt --all -- --check 2>/dev/null
+        run: cargo +1.80.0-${{ matrix.target }} fmt --all -- --check
       - name: Check binaries
         id: bins
         run: cargo +1.80.0-${{ matrix.target }} check --workspace --bins

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,7 @@ jobs:
         run: cargo +1.80.0 check --target ${{ matrix.target }} --workspace --examples
       - name: Run tests
         id: run-tests
-        if: ${{ steps.check-tests.conclusion == 'success' }}
+        if: ${{ steps.check-tests.outcome == 'success' }}
         run: cargo +1.80.0 test --target ${{ matrix.target }} --workspace --no-fail-fast
       - name: Obtain job id
         id: obtain-job-id

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,24 +29,20 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: Approve PR
-        if: ${{ success() }}
-        uses: actions/github-script@v7
+      - uses: actions/github-script@v7
         with:
           script: |
-            await github.rest.pulls.createReview({
-              ...context.repo,
-              pull_number: context.issue.number,
-              event: 'APPROVE',
-            });
-      - name: Request changes
-        if: ${{ failure() }}
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.pulls.createReview({
-              ...context.repo,
-              pull_number: context.issue.number,
-              event: 'REQUEST_CHANGES',
-              body: 'TBD',
-            });
+            if (${{ needs.check-formatting.result == 'success' }}) {
+              await github.rest.pulls.createReview({
+                ...context.repo,
+                pull_number: context.issue.number,
+                event: 'APPROVE',
+              });
+            } else {
+              await github.rest.pulls.createReview({
+                ...context.repo,
+                pull_number: context.issue.number,
+                event: 'REQUEST_CHANGES',
+                body: 'TBD',
+              });
+            }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,6 +72,8 @@ jobs:
       - name: Obtain job id
         id: obtain-job-id
         if: ${{ always() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           jobs=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id}}/attempts/${{ github.run_attempt }}/jobs)
           job_id=$(echo $jobs | jq -r '.jobs[] | select(.name | contains("${{ matrix.name }}")) | .id')

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -43,7 +43,7 @@ jobs:
       - check-formatting
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,15 +55,15 @@ jobs:
           targets: ${{ matrix.target }}
       - name: Build binaries
         id: check-bins
-        continue-on-error: true
+        if: ${{ always() }}
         run: cargo +1.80.0 check --target ${{ matrix.target }} --workspace --bins
       - name: Build tests
         id: check-tests
-        continue-on-error: true
+        if: ${{ always() }}
         run: cargo +1.80.0 check --target ${{ matrix.target }} --workspace --tests
       - name: Build examples
         id: check-examples
-        continue-on-error: true
+        if: ${{ always() }}
         run: cargo +1.80.0 check --target ${{ matrix.target }} --workspace --examples
       - name: Run tests
         id: run-tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,15 +53,15 @@ jobs:
           toolchain: 1.80.0
           components: rustfmt
           targets: ${{ matrix.target }}
-      - name: Check binaries
+      - name: Build binaries
         id: check-bins
         continue-on-error: true
         run: cargo +1.80.0 check --target ${{ matrix.target }} --workspace --bins
-      - name: Check tests
+      - name: Build tests
         id: check-tests
         continue-on-error: true
         run: cargo +1.80.0 check --target ${{ matrix.target }} --workspace --tests
-      - name: Check examples
+      - name: Build examples
         id: check-examples
         continue-on-error: true
         run: cargo +1.80.0 check --target ${{ matrix.target }} --workspace --examples

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.80.0
+          components: rustfmt
           targets: ${{ matrix.target }}
       - name: Check formatting
         id: formatting

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -131,6 +131,9 @@ jobs:
                     (VERBOSE || job.conclusion == 'failure')) {
                   let platform = job.name.split(' ')[1];
                   for (let step of job.steps) {
+                    console.log('Step name: ', step.name);
+                    console.log('Step conclusion: ', step.conclusion);
+                    console.log('Step outcome: ', step.outcome);
                     if (step.name.startsWith('Build ') || step.name.startsWith('Run ') &&
                         (VERBOSE || step.conclusion == 'failure')) {
                       let name = step.name;

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,8 +67,11 @@ jobs:
         run: cargo +1.80.0 check --target ${{ matrix.target }} --workspace --examples
       - name: Run tests
         id: run-tests
-        if: ${{ steps.check-tests.outcome == 'success' }}
-        run: cargo +1.80.0 test --target ${{ matrix.target }} --workspace --no-fail-fast
+        if: ${{ always() }}
+        run: |
+          echo "steps.check-examples.conclusion = ${{ steps.check-examples.conclusion }}"
+          echo "steps.check-examples.outcome = ${{ steps.check-examples.outcome }}"
+          cargo +1.80.0 test --target ${{ matrix.target }} --workspace --no-fail-fast
       - name: Obtain job id
         id: obtain-job-id
         if: ${{ always() }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,7 +78,6 @@ jobs:
         run: |
           jobs=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id}}/attempts/${{ github.run_attempt }}/jobs)
           job_id=$(echo $jobs | jq -r '.jobs[] | select(.name | contains("${{ matrix.name }}")) | .id')
-          echo "job_id is $job_id"
           echo "result=$job_id" >> $GITHUB_OUTPUT
   review-pr:
     name: Review PR

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,8 @@ jobs:
             target: x86_64-pc-windows-gnu
     name: Check ${{ matrix.name }}
     runs-on: ubuntu-latest
+    needs:
+      - check-formatting
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,10 @@ jobs:
           toolchain: 1.80.0
           components: rustfmt
           targets: ${{ matrix.target }}
+      - name: Buiild library
+        id: check-lib
+        if: ${{ always() }}
+        run: cargo +1.80.0 check --target ${{ matrix.target }} --workspace --lib
       - name: Build binaries
         id: check-bins
         if: ${{ always() }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,7 +135,7 @@ jobs:
                         (VERBOSE || step.conclusion != 'success')) {
                       let name = step.name;
                       let succeed = step.conclusion == 'success' ? '✅' : '❌';
-                      let url = get_step_url(job.id, step.id);
+                      let url = get_step_url(job.id, step.number);
                       body += `| ${platform} | ${name} | ${succeed} | [Details](${url}) |\n`;
                     }
                   }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,12 +20,46 @@ jobs:
           components: rustfmt
       - name: Check formatting
         run: cargo +1.80.0 fmt --all -- --check 2>/dev/null
+  check-targets:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux
+            target: x86_64-unknown-linux-gnu
+          - name: MacOS
+            target: x86_64-apple-darwin
+          - name: Windows
+            target: x86_64-pc-windows-gnu
+    name: Check ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.80.0
+          targets: ${{ matrix.target }}
+      - name: Check formatting
+        id: formatting
+        run: cargo +1.80.0-${{ matrix.target }} fmt --all -- --check 2>/dev/null
+      - name: Check binaries
+        id: bins
+        run: cargo +1.80.0-${{ matrix.target }} check --workspace --bins
+      - name: Check tests
+        id: tests
+        run: cargo +1.80.0-${{ matrix.target }} check --workspace --tests
+      - name: Check examples
+        id: examples
+        run: cargo +1.80.0-${{ matrix.target }} check --workspace --examples
   review-pr:
     name: Review PR
     runs-on: ubuntu-latest
     if: ${{ always() }}
     needs:
       - check-formatting
+      - check-targets
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,12 +17,13 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Install Rust
+        id: install-rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.80.0
+          toolchain: stable
           components: rustfmt
       - name: Check formatting
-        run: cargo +1.80.0 fmt --all -- --check 2>/dev/null
+        run: cargo +${{ steps.install-rust.outputs.name }} fmt --all -- --check 2>/dev/null
   check-targets:
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,12 +30,15 @@ jobs:
         include:
           - name: Linux
             target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
           - name: MacOS
             target: x86_64-apple-darwin
+            os: macos-latest
           - name: Windows
             target: x86_64-pc-windows-gnu
+            os: windows-latest
     name: Check ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     needs:
       - check-formatting
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,17 +92,77 @@ jobs:
       - uses: actions/github-script@v7
         with:
           script: |
-            if (${{ needs.check-formatting.result == 'success' }}) {
+            let response = undefined;
+
+            function get_step_id(job_id, name) {
+              if (response == undefined) {
+              }
+              
+              return response.data.jobs
+                .find(job => job.id == job_id).steps
+                .find(step => step.name == name).id;
+            }
+
+            function get_job_url(job_id) {
+              return `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/jobs/${job_id}?check_suite_focus=true`;
+            }
+            
+            function get_step_url(job_id, step_id) {
+              let job_url = get_job_url(job_id);
+              return `${job_url}#step:${step_id}:0`;
+            }
+            
+            if (${{ needs.check-formatting.result != 'success' }} ||
+                ${{ needs.check-targets.result != 'success' }}) {
+              let FORMATTING_JOB_NAME = 'Check formatting';
+              let VERBOSE = true;
+
+              let body = `
+                ## ⚠️ CI failed
+
+                | Platform | Name | Status | Details |
+                | --- | --- | --- | --- |
+              `;
+              
+              let response = await github.rest.actions.getWorkflowRunAttempt({
+                ...context.repo,
+                run_id: context.runId,
+                attempt_number: context.runAttempt
+              });
+
+              let formatting_job = response.data.jobs.find(job => job.name.includes(FORMATTING_JOB_NAME));
+              if (formatting_job != undefined && formatting_job.status != 'success') {
+                let succeed = formatting_job.status == 'success' ? '✅' : '❌';
+                let url = get_job_url(formatting_job.id);
+                body += `| | Formatting | ${succeed} | [Details](${url}) |\n`;
+              }
+
+              for (let job of response.data.jobs) {
+                if (job.name.startsWith('Check') && job.name != formatting_job.name &&
+                    (VERBOSE || job.status != 'success')) {
+                  let platform = job.name.split(' ')[1];
+                  for (let step of job.steps) {
+                    if (step.name.startsWith('Build ') || step.name.startsWith('Run ') &&
+                        (VERBOSE || step.status != 'success')) {
+                      let name = step.name;
+                      let succeed = step.status == 'success' ? '✅' : '❌';
+                      let url = get_step_url(job.id, step.id);
+                      body += `| ${platform} | ${name} | ${status} | [Details](${url}) |\n`;
+                    }
+                  }
+                }
+              }
+            
               await github.rest.pulls.createReview({
                 ...context.repo,
                 pull_number: context.issue.number,
-                event: 'APPROVE',
+                event: 'REQUEST_CHANGES',
+                body: body,
               });
             } else {
               await github.rest.pulls.createReview({
                 ...context.repo,
                 pull_number: context.issue.number,
-                event: 'REQUEST_CHANGES',
-                body: 'TBD',
+                event: 'APPROVE',
               });
             }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,7 +105,7 @@ jobs:
             | --- | --- | --- | --- |\n`;
 
               function get_job_url(job_id) {
-                return `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/jobs/${job_id}?check_suite_focus=true`;
+                return `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/job/${job_id}?check_suite_focus=true`;
               }
               
               function get_step_url(job_id, step_id) {

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,10 @@ jobs:
   review-pr:
     name: Review PR
     runs-on: ubuntu-latest
+    needs:
+      - check-formatting
+    permissions:
+      pull-requests: write
     steps:
       - name: Approve PR
         if: ${{ success() }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -134,9 +134,25 @@ jobs:
                     if (step.name.startsWith('Build ') || step.name.startsWith('Run ') &&
                         (VERBOSE || step.conclusion == 'failure')) {
                       let name = step.name;
-                      let succeed = step.conclusion == 'success' ? '✅' : '❌';
+                      let icon = '';
+                      switch (step.conclusion) {
+                        case 'success':
+                          icon = '✅';
+                          break;
+                        case 'skipped':
+                          icon = '⏩';
+                          break;
+                        case 'failure':
+                        case 'cancelled':
+                          icon = '❌';
+                          break;
+                        default:
+                          // Should never reach here.
+                          icon = '❓';
+                          break;
+                      }
                       let url = get_step_url(job.id, step.number);
-                      body += `| ${platform} | ${name} | ${succeed} | [Details](${url}) |\n`;
+                      body += `| ${platform} | ${name} | ${icon} | [Details](${url}) |\n`;
                     }
                   }
                 }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,7 +114,7 @@ jobs:
                 return `${job_url}#step:${step_id}:0`;
               }
               
-              response = await github.rest.actions.getWorkflowRunAttempt({
+              response = await github.rest.actions.listJobsForWorkflowRunAttempt({
                 ...context.repo,
                 run_id: context.runId,
                 attempt_number: context.runAttempt || 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,7 +123,7 @@ jobs:
               if (formatting_job != undefined && (VERBOSE || formatting_job.conclusion != 'success')) {
                 let succeed = formatting_job.conclusion == 'success' ? '✅' : '❌';
                 let url = get_job_url(formatting_job.id);
-                body += `| | Formatting | ${succeed} | [Details](${url}) |\n`;
+                body += `| All | Formatting | ${succeed} | [Details](${url}) |\n`;
               }
 
               for (let job of response.data.jobs) {

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,12 +31,12 @@ jobs:
           - name: Linux
             target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-          - name: macOS
-            target: x86_64-apple-darwin
-            os: macos-latest
-          - name: Windows
-            target: x86_64-pc-windows-gnu
-            os: windows-latest
+          # - name: macOS
+          #   target: x86_64-apple-darwin
+          #   os: macos-latest
+          # - name: Windows
+          #   target: x86_64-pc-windows-gnu
+          #   os: windows-latest
     name: Check ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     needs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -120,7 +120,7 @@ jobs:
               });
 
               let formatting_job = response.data.jobs.find(job => job.name.includes(FORMATTING_JOB_NAME));
-              if (formatting_job != undefined && (VERBOSE || formatting_job.conclusion != 'success')) {
+              if (formatting_job != undefined && (VERBOSE || formatting_job.conclusion == 'failure')) {
                 let succeed = formatting_job.conclusion == 'success' ? '✅' : '❌';
                 let url = get_job_url(formatting_job.id);
                 body += `| All | Formatting | ${succeed} | [Details](${url}) |\n`;
@@ -128,11 +128,11 @@ jobs:
 
               for (let job of response.data.jobs) {
                 if (job.name.startsWith('Check') && job.name != formatting_job.name &&
-                    (VERBOSE || job.conclusion != 'success')) {
+                    (VERBOSE || job.conclusion == 'failure')) {
                   let platform = job.name.split(' ')[1];
                   for (let step of job.steps) {
                     if (step.name.startsWith('Build ') || step.name.startsWith('Run ') &&
-                        (VERBOSE || step.conclusion != 'success')) {
+                        (VERBOSE || step.conclusion == 'failure')) {
                       let name = step.name;
                       let succeed = step.conclusion == 'success' ? '✅' : '❌';
                       let url = get_step_url(job.id, step.number);

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,6 +69,14 @@ jobs:
         id: run-tests
         if: ${{ steps.check-tests.outcome == 'success' }}
         run: cargo +1.80.0 test --target ${{ matrix.target }} --workspace --no-fail-fast
+      - name: Obtain job id
+        id: obtain-job-id
+        if: ${{ always() }}
+        run: |
+          jobs=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id}}/attempts/${{ github.run_attempt }}/jobs)
+          job_id=$(echo $jobs | jq -r '.jobs[] | select(.name | contains("${{ matrix.name }}")) | .id')
+          echo "job_id is $job_id"
+          echo "result=$job_id" >> $GITHUB_OUTPUT
   review-pr:
     name: Review PR
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,15 +55,19 @@ jobs:
           targets: ${{ matrix.target }}
       - name: Check binaries
         id: check-bins
+        continue-on-error: true
         run: cargo +1.80.0 check --target ${{ matrix.target }} --workspace --bins
       - name: Check tests
         id: check-tests
+        continue-on-error: true
         run: cargo +1.80.0 check --target ${{ matrix.target }} --workspace --tests
       - name: Check examples
         id: check-examples
+        continue-on-error: true
         run: cargo +1.80.0 check --target ${{ matrix.target }} --workspace --examples
       - name: Run tests
         id: run-tests
+        if: ${{ steps.check-tests.outcome == 'success' }}
         run: cargo +1.80.0 test --target ${{ matrix.target }} --workspace --no-fail-fast
   review-pr:
     name: Review PR

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,23 +121,23 @@ jobs:
               });
 
               let formatting_job = response.data.jobs.find(job => job.name.includes(FORMATTING_JOB_NAME));
-              if (formatting_job != undefined && formatting_job.status != 'success') {
-                let succeed = formatting_job.status == 'success' ? '✅' : '❌';
+              if (formatting_job != undefined && (VERBOSE || formatting_job.conclusion != 'success')) {
+                let succeed = formatting_job.conclusion == 'success' ? '✅' : '❌';
                 let url = get_job_url(formatting_job.id);
                 body += `| | Formatting | ${succeed} | [Details](${url}) |\n`;
               }
 
               for (let job of response.data.jobs) {
                 if (job.name.startsWith('Check') && job.name != formatting_job.name &&
-                    (VERBOSE || job.status != 'success')) {
+                    (VERBOSE || job.conclusion != 'success')) {
                   let platform = job.name.split(' ')[1];
                   for (let step of job.steps) {
                     if (step.name.startsWith('Build ') || step.name.startsWith('Run ') &&
-                        (VERBOSE || step.status != 'success')) {
+                        (VERBOSE || step.conclusion != 'success')) {
                       let name = step.name;
-                      let succeed = step.status == 'success' ? '✅' : '❌';
+                      let succeed = step.conclusion == 'success' ? '✅' : '❌';
                       let url = get_step_url(job.id, step.id);
-                      body += `| ${platform} | ${name} | ${status} | [Details](${url}) |\n`;
+                      body += `| ${platform} | ${name} | ${succeed} | [Details](${url}) |\n`;
                     }
                   }
                 }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,7 @@ jobs:
         id: install-rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.70.0
+          toolchain: 1.74.0
           components: rustfmt
           targets: ${{ matrix.target }}
       - name: Build library

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,11 +99,10 @@ jobs:
               let response = undefined;
 
               let body = `
-                ## ⚠️ CI failed
+            ## ⚠️ CI failed
 
-                | Platform | Name | Status | Details |
-                | --- | --- | --- | --- |
-              `;
+            | Platform | Name | Status | Details |
+            | --- | --- | --- | --- |`;
 
               function get_job_url(job_id) {
                 return `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/jobs/${job_id}?check_suite_focus=true`;

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
           toolchain: 1.80.0
           components: rustfmt
           targets: ${{ matrix.target }}
-      - name: Buiild library
+      - name: Build library
         id: check-lib
         if: ${{ always() }}
         run: cargo +1.80.0 check --target ${{ matrix.target }} --workspace --lib

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,30 +92,11 @@ jobs:
       - uses: actions/github-script@v7
         with:
           script: |
-            let response = undefined;
-
-            function get_step_id(job_id, name) {
-              if (response == undefined) {
-              }
-              
-              return response.data.jobs
-                .find(job => job.id == job_id).steps
-                .find(step => step.name == name).id;
-            }
-
-            function get_job_url(job_id) {
-              return `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/jobs/${job_id}?check_suite_focus=true`;
-            }
-            
-            function get_step_url(job_id, step_id) {
-              let job_url = get_job_url(job_id);
-              return `${job_url}#step:${step_id}:0`;
-            }
-            
             if (${{ needs.check-formatting.result != 'success' }} ||
                 ${{ needs.check-targets.result != 'success' }}) {
               let FORMATTING_JOB_NAME = 'Check formatting';
               let VERBOSE = true;
+              let response = undefined;
 
               let body = `
                 ## ⚠️ CI failed
@@ -123,8 +104,17 @@ jobs:
                 | Platform | Name | Status | Details |
                 | --- | --- | --- | --- |
               `;
+
+              function get_job_url(job_id) {
+                return `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/jobs/${job_id}?check_suite_focus=true`;
+              }
               
-              let response = await github.rest.actions.getWorkflowRunAttempt({
+              function get_step_url(job_id, step_id) {
+                let job_url = get_job_url(job_id);
+                return `${job_url}#step:${step_id}:0`;
+              }
+              
+              response = await github.rest.actions.getWorkflowRunAttempt({
                 ...context.repo,
                 run_id: context.runId,
                 attempt_number: context.runAttempt || 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,14 +54,17 @@ jobs:
           components: rustfmt
           targets: ${{ matrix.target }}
       - name: Check binaries
-        id: bins
+        id: check-bins
         run: cargo +1.80.0 check --target ${{ matrix.target }} --workspace --bins
       - name: Check tests
-        id: tests
+        id: check-tests
         run: cargo +1.80.0 check --target ${{ matrix.target }} --workspace --tests
       - name: Check examples
-        id: examples
+        id: check-examples
         run: cargo +1.80.0 check --target ${{ matrix.target }} --workspace --examples
+      - name: Run tests
+        id: run-tests
+        run: cargo +1.80.0 test --target ${{ matrix.target }} --workspace --no-fail-fast
   review-pr:
     name: Review PR
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,7 +95,7 @@ jobs:
             if (${{ needs.check-formatting.result != 'success' }} ||
                 ${{ needs.check-targets.result != 'success' }}) {
               let FORMATTING_JOB_NAME = 'Check formatting';
-              let VERBOSE = true;
+              let VERBOSE = false;
               let response = undefined;
 
               let body = `

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,19 +58,19 @@ jobs:
       - name: Build library
         id: check-lib
         if: ${{ always() }}
-        run: cargo +${{ steps.install-rust.outputs.name }} check --target ${{ matrix.target }} --workspace --lib
+        run: cargo +${{ steps.install-rust.outputs.name }} check --target ${{ matrix.target }} --workspace --keep-going --lib
       - name: Build binaries
         id: check-bins
         if: ${{ always() }}
-        run: cargo +${{ steps.install-rust.outputs.name }} check --target ${{ matrix.target }} --workspace --bins
+        run: cargo +${{ steps.install-rust.outputs.name }} check --target ${{ matrix.target }} --workspace --keep-going --bins
       - name: Build tests
         id: check-tests
         if: ${{ always() }}
-        run: cargo +${{ steps.install-rust.outputs.name }} check --target ${{ matrix.target }} --workspace --tests
+        run: cargo +${{ steps.install-rust.outputs.name }} check --target ${{ matrix.target }} --workspace --keep-going --tests
       - name: Build examples
         id: check-examples
         if: ${{ always() }}
-        run: cargo +${{ steps.install-rust.outputs.name }} check --target ${{ matrix.target }} --workspace --examples
+        run: cargo +${{ steps.install-rust.outputs.name }} check --target ${{ matrix.target }} --workspace --keep-going --examples
       - name: Run tests
         id: run-tests
         if: ${{ steps.check-tests.outcome == 'success' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,7 @@ jobs:
         id: install-rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.75.0
+          toolchain: 1.81.0
           components: rustfmt
           targets: ${{ matrix.target }}
       - name: Build library


### PR DESCRIPTION
This PR implements a CI workflow which is executed every time a PR is open, reopened or new commits are pushed.
The workflow will checkout HEAD of a pull request branch, and first things first check if formatting is correct.
Then it will run next steps:

- Build library.
- Build binary.
- Build tests.
- Build examples.
- Run tests. (Only if building them was successful)

These all steps could be running on any OS (Linux, macOS, Windows), but since we don't have any cross-platform code right now, I've only left Linux.
If all of the steps succeed, github-actions bot will approve the PR.
If any of steps fail, github-actions bot will request changes and provide a meaningful information about steps that were ran.

All the formatting done using rustfmt from the latest **stable** Rust toolchain release.
All the building and running tests done using Rust version 1.81.0, which is our current MSRV.

This CI **will** run on every commit even for a draft PR. It is intended behavior. If you feel like it should be changed please do let me know.

Just like any other CI it can be skipped including `[skip ci]` or [anything similar](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/skipping-workflow-runs) in commit message.

Here is an example of a failed output:
![image](https://github.com/user-attachments/assets/4eee3f51-f600-4c4a-964b-22728457efde)

As you can see above, I print all the steps performed, even if they were successful.
There is also available a "non-verbose" mode as I call it which can be switched very easily in the code (if you prefer it over verbose), which will only show failed steps, like this:
![image](https://github.com/user-attachments/assets/383e216b-e7d4-4fce-a5d1-c71c197b65ef)

And this is how a verbose mode looks for 3 platforms:
![image](https://github.com/user-attachments/assets/a418f0d2-60d0-4aeb-afb9-5f0a8c731238)

For more examples you can look [here](https://github.com/User344/protoflow/pull/1).