### PR TITLE
Improve CI workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,6 +58,11 @@ jobs:
           toolchain: 1.81.0
           components: rustfmt
           targets: ${{ matrix.target }}
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "29.1"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build library
         id: check-lib
         if: ${{ always() }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,9 @@ name: CI
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
     
 jobs:
   check-formatting:
@@ -84,6 +87,7 @@ jobs:
       - check-formatting
       - check-targets
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - uses: actions/github-script@v7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   check-formatting:
     name: Check formatting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
         include:
           - name: Linux
             target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-24.04
           # - name: macOS
           #   target: x86_64-apple-darwin
           #   os: macos-latest
@@ -81,7 +81,7 @@ jobs:
           cargo +${{ steps.install-rust.outputs.name }} test --target ${{ matrix.target }} --workspace --test "*" --no-fail-fast
   review-pr:
     name: Review PR
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ always() }}
     needs:
       - check-formatting

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@
 name: CI
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
     
 jobs:


### PR DESCRIPTION
In this PR I changed event type due to number of reasons:
- Main reason is to allow CI workflow to run for PRs that are based on branches in forks.
- Also fixes issue where CI wouldn't have ran if merging is not possible due to conflicts (we didn't run into this though).

And I also bumped ubuntu runner version to 24.04 (latest) to get rid of a warning in logs.
![image](https://github.com/user-attachments/assets/42da9d16-d113-4c7b-b9a0-afe718bae23e)