### PR TITLE
Add a `protoflow_blocks::System::const_bytes` helper

### DIFF
--- a/lib/protoflow-blocks/src/blocks/core.rs
+++ b/lib/protoflow-blocks/src/blocks/core.rs
@@ -2,7 +2,7 @@
 
 pub mod core {
     use super::{
-        prelude::{vec, Box, Cow, Named, Vec},
+        prelude::{vec, Box, Bytes, Cow, Named, Vec},
         BlockConnections, BlockInstantiation, InputPortName, OutputPortName, System,
     };
     use crate::{
@@ -13,6 +13,8 @@ pub mod core {
 
     pub trait CoreBlocks {
         fn buffer<T: Message + Into<T> + 'static>(&mut self) -> Buffer<T>;
+
+        fn const_bytes<T: Into<Bytes>>(&mut self, value: T) -> Const<Bytes>;
 
         fn const_string(&mut self, value: impl ToString) -> Const<String>;
 

--- a/lib/protoflow-blocks/src/system.rs
+++ b/lib/protoflow-blocks/src/system.rs
@@ -3,7 +3,7 @@
 #![allow(dead_code)]
 
 use crate::{
-    prelude::{fmt, Arc, Box, FromStr, Rc, String, ToString},
+    prelude::{fmt, Arc, Box, Bytes, FromStr, Rc, String, ToString},
     types::{DelayType, Encoding},
     AllBlocks, Buffer, ConcatStrings, Const, CoreBlocks, Count, Decode, DecodeCsv, DecodeHex,
     DecodeJson, Delay, Drop, Encode, EncodeCsv, EncodeHex, EncodeJson, FlowBlocks, HashBlocks,
@@ -131,6 +131,11 @@ impl AllBlocks for System {}
 impl CoreBlocks for System {
     fn buffer<T: Message + Into<T> + 'static>(&mut self) -> Buffer<T> {
         self.0.block(Buffer::<T>::with_system(self))
+    }
+
+    fn const_bytes<T: Into<Bytes>>(&mut self, value: T) -> Const<Bytes> {
+        self.0
+            .block(Const::<Bytes>::with_system(self, value.into()))
     }
 
     fn const_string(&mut self, value: impl ToString) -> Const<String> {
@@ -306,5 +311,21 @@ impl TextBlocks for System {
     fn split_string(&mut self, delimiter: &str) -> SplitString {
         self.0
             .block(SplitString::with_system(self, Some(delimiter.to_string())))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn const_bytes_accepts_various_types() {
+        let _ = System::build(|s| {
+            let _ = s.const_bytes("Hello world");
+            let _ = s.const_bytes("Hello world".to_string());
+            let _ = s.const_bytes(&b"Hello world"[..]);
+            let _ = s.const_bytes(b"Hello world".to_vec());
+            let _ = s.const_bytes(Bytes::from("Hello world"));
+        });
     }
 }


### PR DESCRIPTION
Reviewing #24 I saw that we're using `sys.const_string --> sys.encode_lines --> [block that takes Bytes]` as a crutch with sometimes unexpected outcomes due to the newlines.
I propose a `sys.const_bytes` helper as a nicer alternative to get the correct behaviour of `Const::<Bytes>::with_system(sys, Bytes::from(...))`.

A generic `Mapper<Input: Message, Output: Message + From<Input>>` block for automating the infallible conversions seems useful too.