### PR TITLE
Fix tests in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,7 +83,7 @@ jobs:
         id: run-tests
         if: ${{ steps.check-tests.outcome == 'success' }}
         run: |
-          cargo +${{ steps.install-rust.outputs.name }} test --target ${{ matrix.target }} --workspace --test "*" --no-fail-fast
+          cargo +${{ steps.install-rust.outputs.name }} test --target ${{ matrix.target }} --workspace --tests --no-fail-fast
   review-pr:
     name: Review PR
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,6 +84,11 @@ jobs:
         if: ${{ steps.check-tests.outcome == 'success' }}
         run: |
           cargo +${{ steps.install-rust.outputs.name }} test --target ${{ matrix.target }} --workspace --tests --no-fail-fast
+      - name: Run doctests
+        id: run-doctests
+        if: ${{ steps.check-tests.outcome == 'success' }}
+        run: |
+          cargo +${{ steps.install-rust.outputs.name }} test --target ${{ matrix.target }} --workspace --doc --no-fail-fast
   review-pr:
     name: Review PR
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Previously due to some weird behavior in `cargo test` command I implemented a certain workaround that breaks running unit tests ([Context](https://github.com/asimov-platform/protoflow/pull/28#issuecomment-2529918901)).
This PR fixes that and also adds running doctests. I initially wanted to implement it in the same command but its not possible, and doing two commands in a single step doesn't look good in the output, thus I decided to make a separate step for that.