### PR TITLE
Refactor usage of tracing crate

### DIFF
--- a/lib/protoflow-blocks/src/blocks/io/decode_hex.rs
+++ b/lib/protoflow-blocks/src/blocks/io/decode_hex.rs
@@ -4,11 +4,9 @@ use crate::{
     prelude::{format, Bytes, Vec},
     IoBlocks, StdioConfig, StdioError, StdioSystem, System,
 };
-use protoflow_core::{Block, BlockError, BlockResult, BlockRuntime, InputPort, OutputPort};
+use protoflow_core::{error, Block, BlockError, BlockResult, BlockRuntime, InputPort, OutputPort};
 use protoflow_derive::Block;
 use simple_mermaid::mermaid;
-#[cfg(feature = "tracing")]
-use tracing;
 
 /// A block that decodes a hexadecimal byte stream to byte.
 ///
@@ -96,8 +94,7 @@ fn hex_value(byte: u8) -> Result<u8, BlockError> {
         b'A'..=b'F' => Ok(byte - b'A' + 10),
         _ => {
             let err = format!("Invalid hex character: '{}' (0x{:02X})", byte as char, byte);
-            #[cfg(feature = "tracing")]
-            tracing::error!(target: "DecodeHex:hex_value", err);
+            error!(target: "DecodeHex:hex_value", err);
             Err(BlockError::Other(err))
         }
     }

--- a/lib/protoflow-blocks/src/blocks/sys/read_socket.rs
+++ b/lib/protoflow-blocks/src/blocks/sys/read_socket.rs
@@ -5,7 +5,8 @@ use crate::{
     StdioConfig, StdioError, StdioSystem, System,
 };
 use protoflow_core::{
-    Block, BlockError, BlockResult, BlockRuntime, OutputPort, Port, PortResult, SystemBuilding,
+    error, info, Block, BlockError, BlockResult, BlockRuntime, OutputPort, Port, PortResult,
+    SystemBuilding,
 };
 use protoflow_derive::Block;
 use serde::{Deserialize, Serialize};
@@ -16,8 +17,6 @@ use std::{
     net::{TcpListener, TcpStream},
     sync::{Arc, Mutex, PoisonError},
 };
-#[cfg(feature = "tracing")]
-use tracing::{error, info};
 
 /// A block that reads a proto object from a TCP port.
 ///
@@ -101,7 +100,6 @@ impl Block for ReadSocket {
     fn prepare(&mut self, _runtime: &dyn BlockRuntime) -> BlockResult {
         let listener = TcpListener::bind(&self.config.connection)?;
         *self.listener.lock().map_err(lock_error)? = Some(listener);
-        #[cfg(feature = "tracing")]
         info!("Server listening on {}", &self.config.connection);
         Ok(())
     }
@@ -116,18 +114,15 @@ impl Block for ReadSocket {
                 .ok_or(BlockError::Other("Invalid TCP listener".into()))?;
 
             let (stream, addr) = listener.accept().map_err(|e| {
-                #[cfg(feature = "tracing")]
                 error!("Failed to accept client connection: {}", e);
                 BlockError::Other("Failed to accept client connection".into())
             })?;
-            #[cfg(feature = "tracing")]
             info!("Accepted connection from {}", addr);
             *stream_guard = Some(stream);
         }
 
         if let Some(stream) = stream_guard.as_mut() {
             handle_client::<_>(stream, self.config.buffer_size, |message| {
-                #[cfg(feature = "tracing")]
                 info!("Processing received message");
                 if self.output.is_connected() {
                     self.output.send(message)?;
@@ -135,7 +130,6 @@ impl Block for ReadSocket {
                 Ok(())
             })
             .map_err(|e| {
-                #[cfg(feature = "tracing")]
                 error!("Error handling client: {}", e);
                 BlockError::Other("Error handling client".into())
             })?;
@@ -163,17 +157,14 @@ where
         let bytes_read = stream.read(&mut buffer)?;
 
         if bytes_read == 0 {
-            #[cfg(feature = "tracing")]
             info!("Client disconnected");
             break;
         }
 
         let message = Bytes::copy_from_slice(&buffer[..bytes_read]);
-        #[cfg(feature = "tracing")]
         info!("Received message: {:?}", message);
 
         if let Err(e) = process_fn(&message) {
-            #[cfg(feature = "tracing")]
             error!("Failed to process message: {:?}", e);
             return Err(BlockError::Other("Failed to process message".into()));
         }
@@ -223,7 +214,6 @@ pub mod read_socket_tests {
             ));
             s.connect(&read_socket.output, &std_out.input);
         }) {
-            #[cfg(feature = "tracing")]
             error!("{}", e)
         }
     }

--- a/lib/protoflow-blocks/src/blocks/sys/write_socket.rs
+++ b/lib/protoflow-blocks/src/blocks/sys/write_socket.rs
@@ -5,7 +5,9 @@ use crate::{
     prelude::{bytes::Bytes, vec, String},
     StdioConfig, StdioError, StdioSystem, System,
 };
-use protoflow_core::{Block, BlockError, BlockResult, BlockRuntime, InputPort, SystemBuilding};
+use protoflow_core::{
+    error, Block, BlockError, BlockResult, BlockRuntime, InputPort, SystemBuilding,
+};
 use protoflow_derive::Block;
 use serde::{Deserialize, Serialize};
 use simple_mermaid::mermaid;
@@ -14,8 +16,6 @@ use std::{
     net::TcpStream,
     sync::{Arc, Mutex, PoisonError},
 };
-#[cfg(feature = "tracing")]
-use tracing::error;
 
 /// A block that writes a proto object to a TCP socket.
 ///
@@ -99,7 +99,6 @@ impl Block for WriteSocket {
 
             if stream_guard.is_none() {
                 *stream_guard = Some(TcpStream::connect(&self.config.connection).map_err(|e| {
-                    #[cfg(feature = "tracing")]
                     error!("Failed to connect to {}: {}", &self.config.connection, e);
                     BlockError::Other(format!(
                         "Failed to connect to {}: {}",
@@ -109,7 +108,6 @@ impl Block for WriteSocket {
             }
 
             let stream = stream_guard.as_mut().ok_or_else(|| {
-                #[cfg(feature = "tracing")]
                 error!("Stream is not connected");
                 BlockError::Other("Stream is not connected".into())
             })?;
@@ -158,7 +156,6 @@ pub mod write_socket_tests {
             });
             s.connect(&stdin.output, &write_socket.input);
         }) {
-            #[cfg(feature = "tracing")]
             error!("{}", e)
         }
     }

--- a/lib/protoflow-core/src/lib.rs
+++ b/lib/protoflow-core/src/lib.rs
@@ -95,3 +95,23 @@ pub(crate) mod utils {
 pub use prost_types as types;
 
 pub use prost::DecodeError;
+
+#[cfg(feature = "tracing")]
+#[doc(hidden)]
+mod tracing {
+    pub use tracing::{debug, error, info, trace, warn};
+}
+
+#[cfg(not(feature = "tracing"))]
+#[doc(hidden)]
+#[rustfmt::skip]
+mod tracing {
+    #[macro_export] macro_rules! debug { ($($arg:tt)+) => (); }
+    #[macro_export] macro_rules! error { ($($arg:tt)+) => (); }
+    #[macro_export] macro_rules! info { ($($arg:tt)+) => (); }
+    #[macro_export] macro_rules! trace { ($($arg:tt)+) => (); }
+    #[macro_export] macro_rules! warn { ($($arg:tt)+) => (); }
+}
+
+#[allow(unused)]
+pub use tracing::*;


### PR DESCRIPTION
This PR improves usage of tracing library by abstracting away feature gate and making a simple no-op macro in case tracing feature is not turned on.
The main drawback of this PR is that all `debug`, `error`, `info`, `trace` and `warn` macros **have** to be exported in `protoflow_core` crate root, instead of being exported in something handly like `crate::prelude::tracing::{debug, error}`. I don't think its possible to not have it in root without making a whole new package.

Also tracing currently is only used in `WriteSocket` and `ReadSocket` blocks.