### PR TITLE
Temporarily disable write_file::run_block test

### DIFF
--- a/lib/protoflow-blocks/src/blocks/sys/write_file.rs
+++ b/lib/protoflow-blocks/src/blocks/sys/write_file.rs
@@ -164,6 +164,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "temporarily disabled"]
     fn run_block() {
         use std::{fs::File, io::Read, string::String};
 


### PR DESCRIPTION
It appears there is currently a bug which makes WriteFile's `run_block` test to fail on CI. I am still unsure if it was introduced by some PR or something else. I've checked all the versions (Ubuntu, GitHub runner's image, Rust toolchain, etc) and all of them seems to be the same, so it's unclear what changed that made the test fail.
Until I figure out and fix the issue, the test should be disabled so it doesn't interfere with other PRs.