### PR TITLE
Add `traits` feature for `dogma` dependency in `protoflow-core`

### DIFF
--- a/lib/protoflow-core/Cargo.toml
+++ b/lib/protoflow-core/Cargo.toml
@@ -40,7 +40,7 @@ cfg_aliases.workspace = true
 
 [dependencies]
 bytes = { version = "1", default-features = false }
-dogma = { version = "0.1", default-features = false }
+dogma = { version = "0.1", default-features = false, features = ["traits"] }
 getrandom = { version = "0.2", optional = true, default-features = false }
 parking_lot = "0.12"
 prost = { version = "0.13", default-features = false, features = ["derive"] }


### PR DESCRIPTION
`protoflow-core` depends on `dogma` version `0.1` which by default pulls the latest `0.1.8`.
`protoflow-core` then uses the `traits` module here: 
https://github.com/asimov-platform/protoflow/blob/0cda080fc559c14361cd83c6ffb4b1b99ef06150/lib/protoflow-core/src/prelude.rs#L62

But `dogma` has feature-gated that behind `traits` since around `0.1.3`:
https://github.com/dogmatists/dogma.rs/commit/eeb838cce2205213867c16cb7ef581746f51b458

The error:
```
error[E0432]: unresolved import `dogma::traits`
  --> lib/protoflow-core/src/prelude.rs:62:16
   |
62 | pub use dogma::traits::{Labeled, MaybeLabeled, MaybeNamed, Named};
   |                ^^^^^^ could not find `traits` in `dogma`
   |
note: found an item that was configured out
  --> ~/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/dogma-0.1.8/src/lib.rs:36:9
   |
36 | pub mod traits;
   |         ^^^^^^
note: the item is gated here
  --> ~/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/dogma-0.1.8/src/lib.rs:27:1
   |
27 | / #[cfg(any(
28 | |     feature = "traits",
29 | |     any(
30 | |         feature = "collection",
...  |
35 | | ))]
   | |___^
```

Outcomes:
1. A clean checkout of this repo fails (you can also see this by doing `rm Cargo.lock && cargo check`, your lockfile—like mine—probably has a version with which everything here seems to be fine)
2. Crates that depend on `protoflow-core` are also broken if they neither pin `dogma = "=0.1.2"` in their `Cargo.toml` nor have a lockfile with `<0.1.3`